### PR TITLE
Remove node==9 pin

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,7 @@
 channels:
     - conda-forge
 dependencies:
-    - nodejs=9
     - matplotlib
-    - jupyterlab>=0.33
+    - jupyterlab>=0.35
     - pip:
       - jupyterlab_latex


### PR DESCRIPTION
Is no longer required by JupyterLab.

Also bump JupyterLab version