### PR TITLE
Resolves failure to build binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ for Binder. This repository also makes use of [JupyterLab Latex](https://github.
 
 * `apt.txt` for apt-installing the latex components
 * `environment.yml` for installing the python dependencies
-* `postBuild` for forcing matplotlib to build the font cache and for installing JupyterLab Latex.
+* `postBuild` for forcing matplotlib to build the font cache
 
 Thanks to [m-weigand](https://github.com/m-weigand) for giving
 [inspiration for this repo](https://github.com/m-weigand/binder-example-latex-mpl/blob/master/index.ipynb)!

--- a/apt.txt
+++ b/apt.txt
@@ -1,7 +1,7 @@
 dvipng
 ghostscript
 texlive-fonts-recommended
-texlive-generic-recommended
+texlive-plain-generic
 texlive-latex-base
 texlive-latex-extra
 texlive-latex-recommended

--- a/index.ipynb
+++ b/index.ipynb
@@ -38,7 +38,7 @@
    ],
    "source": [
     "fig, ax = plt.subplots()\n",
-    "ax.text(.5, .5, \"\\LaTeX $r_{ez}^{ul}$!!!!!!\", fontsize=30, horizontalalignment='center')\n",
+    "ax.text(.5, .5, r\"\\LaTeX $r_{ez}^{ul}$!!!!!!\", fontsize=30, horizontalalignment='center')\n",
     "ax.set_axis_off()"
    ]
   },

--- a/postBuild
+++ b/postBuild
@@ -4,6 +4,3 @@
 python -c "import matplotlib as mpl; mpl.use('Agg'); import pylab as plt; fig, ax = plt.subplots(); fig.savefig('test.png')"
 
 test -e test.png && rm test.png
-
-# install JupyterLab extension
-jupyter labextension install @jupyterlab/latex


### PR DESCRIPTION
Resolves #14 

Changed `apt.txt` to install package `texlive-plain-generic` (removed `texlive-generic-recommended`) 

per [this issue](https://github.com/jupyter/nbconvert/issues/1518) and the [debian package texlive-generic-recommended](https://packages.debian.org/buster/texlive-generic-recommended) being listed as "a transitional package for texlive-generic-recommended to ensure proper upgrade to texlive-plain-generic"